### PR TITLE
Discard master and slave terminology

### DIFF
--- a/tyk/config/config.go
+++ b/tyk/config/config.go
@@ -147,7 +147,7 @@ type WebHookHandlerConf struct {
 	EventTimeout int64             `bson:"event_timeout" json:"event_timeout"`
 }
 
-type SlaveOptionsConfig struct {
+type SubordinateOptionsConfig struct {
 	UseRPC                          bool   `json:"use_rpc"`
 	UseSSL                          bool   `json:"use_ssl"`
 	SSLInsecureSkipVerify           bool   `json:"ssl_insecure_skip_verify"`
@@ -280,8 +280,8 @@ type Config struct {
 	Storage                  StorageOptionsConf     `json:"storage"`
 	DisableDashboardZeroConf bool                   `json:"disable_dashboard_zeroconf"`
 
-	// Slave Configurations
-	SlaveOptions   SlaveOptionsConfig `json:"slave_options"`
+	// Subordinate Configurations
+	SubordinateOptions   SubordinateOptionsConfig `json:"subordinate_options"`
 	ManagementNode bool               `json:"management_node"`
 	AuthOverride   AuthOverrideConf   `json:"auth_override"`
 
@@ -305,10 +305,10 @@ type Config struct {
 	CloseIdleConnections bool  `json:"close_idle_connections"`
 	CloseConnections     bool  `json:"close_connections"`
 	EnableCustomDomains  bool  `json:"enable_custom_domains"`
-	// If AllowMasterKeys is set to true, session objects (key definitions) that do not have explicit access rights set
+	// If AllowMainKeys is set to true, session objects (key definitions) that do not have explicit access rights set
 	// will be allowed by Tyk. This means that keys that are created have access to ALL APIs, which in many cases is
 	// unwanted behaviour unless you are sure about what you are doing.
-	AllowMasterKeys bool `json:"allow_master_keys"`
+	AllowMainKeys bool `json:"allow_main_keys"`
 
 	// Gateway-Service Configuration
 	ServiceDiscovery              ServiceDiscoveryConf `json:"service_discovery"`

--- a/tyk/gateway/api.go
+++ b/tyk/gateway/api.go
@@ -231,9 +231,9 @@ func doAddOrUpdate(keyName string, newSession *user.SessionState, dontReset bool
 		}
 	} else {
 		// nothing defined, add key to ALL
-		if !config.Global().AllowMasterKeys {
-			log.Error("Master keys disallowed in configuration, key not added.")
-			return errors.New("Master keys not allowed")
+		if !config.Global().AllowMainKeys {
+			log.Error("Main keys disallowed in configuration, key not added.")
+			return errors.New("Main keys not allowed")
 		}
 		log.Warning("No API Access Rights set, adding key to ALL.")
 		apisMu.RLock()
@@ -549,7 +549,7 @@ func handleAddKey(keyName, hashedName, sessionString, apiID string) {
 		"prefix": "RPC",
 		"key":    obfuscateKey(keyName),
 		"status": "ok",
-	}).Info("Updated hashed key in slave storage.")
+	}).Info("Updated hashed key in subordinate storage.")
 }
 
 func handleDeleteKey(keyName, apiID string) (interface{}, int) {
@@ -1221,7 +1221,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
-		if config.Global().AllowMasterKeys {
+		if config.Global().AllowMainKeys {
 			// nothing defined, add key to ALL
 			log.WithFields(logrus.Fields{
 				"prefix":      "api",
@@ -1253,14 +1253,14 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 			log.WithFields(logrus.Fields{
 				"prefix":      "api",
 				"status":      "error",
-				"err":         "master keys disabled",
+				"err":         "main keys disabled",
 				"org_id":      newSession.OrgID,
 				"api_id":      "--",
 				"user_id":     "system",
 				"user_ip":     requestIPHops(r),
 				"path":        "--",
 				"server_name": "system",
-			}).Error("Master keys disallowed in configuration, key not added.")
+			}).Error("Main keys disallowed in configuration, key not added.")
 
 			doJSONWrite(w, http.StatusBadRequest, apiError("Failed to create key, keys must have at least one Access Rights record set."))
 			return

--- a/tyk/gateway/api_test.go
+++ b/tyk/gateway/api_test.go
@@ -139,8 +139,8 @@ func TestKeyHandler(t *testing.T) {
 	})
 
 	// Access right not specified
-	masterKey := CreateStandardSession()
-	masterKeyJSON, _ := json.Marshal(masterKey)
+	mainKey := CreateStandardSession()
+	mainKeyJSON, _ := json.Marshal(mainKey)
 
 	// with access
 	withAccess := CreateStandardSession()
@@ -177,8 +177,8 @@ func TestKeyHandler(t *testing.T) {
 
 	t.Run("Create key", func(t *testing.T) {
 		ts.Run(t, []test.TestCase{
-			// Master keys should be disabled by default
-			{Method: "POST", Path: "/tyk/keys/create", Data: string(masterKeyJSON), AdminAuth: true, Code: 400, BodyMatch: "Failed to create key, keys must have at least one Access Rights record set."},
+			// Main keys should be disabled by default
+			{Method: "POST", Path: "/tyk/keys/create", Data: string(mainKeyJSON), AdminAuth: true, Code: 400, BodyMatch: "Failed to create key, keys must have at least one Access Rights record set."},
 			{Method: "POST", Path: "/tyk/keys/create", Data: string(withAccessJSON), AdminAuth: true, Code: 200},
 		}...)
 	})

--- a/tyk/gateway/host_checker_manager.go
+++ b/tyk/gateway/host_checker_manager.go
@@ -108,7 +108,7 @@ func (hc *HostCheckerManager) CheckActivePollerLoop() {
 		} else {
 			log.WithFields(logrus.Fields{
 				"prefix": "host-check-mgr",
-			}).Debug("New master found, no tests running")
+			}).Debug("New main found, no tests running")
 			if hc.pollerStarted {
 				hc.StopPoller()
 				hc.pollerStarted = false
@@ -143,7 +143,7 @@ func (hc *HostCheckerManager) AmIPolling() bool {
 	if activeInstance == hc.Id {
 		log.WithFields(logrus.Fields{
 			"prefix": "host-check-mgr",
-		}).Debug("Primary instance set, I am master")
+		}).Debug("Primary instance set, I am main")
 		hc.store.SetKey(PollerCacheKey, hc.Id, 15) // Reset TTL
 		return true
 	}

--- a/tyk/gateway/redis_signal_handle_config.go
+++ b/tyk/gateway/redis_signal_handle_config.go
@@ -118,7 +118,7 @@ func sanitizeConfig(mc map[string]interface{}) map[string]interface{} {
 		"secret",
 		"node_secret",
 		"storage",
-		"slave_options",
+		"subordinate_options",
 		"auth_override",
 	}
 	for _, field_name := range sanitzeFields {

--- a/tyk/gateway/rpc_storage_handler.go
+++ b/tyk/gateway/rpc_storage_handler.go
@@ -128,17 +128,17 @@ var RPCGlobalCache = cache.New(30*time.Second, 15*time.Second)
 
 // Connect will establish a connection to the RPC
 func (r *RPCStorageHandler) Connect() bool {
-	slaveOptions := config.Global().SlaveOptions
+	subordinateOptions := config.Global().SubordinateOptions
 	rpcConfig := rpc.Config{
-		UseSSL:                slaveOptions.UseSSL,
-		SSLInsecureSkipVerify: slaveOptions.SSLInsecureSkipVerify,
-		ConnectionString:      slaveOptions.ConnectionString,
-		RPCKey:                slaveOptions.RPCKey,
-		APIKey:                slaveOptions.APIKey,
-		GroupID:               slaveOptions.GroupID,
-		CallTimeout:           slaveOptions.CallTimeout,
-		PingTimeout:           slaveOptions.PingTimeout,
-		RPCPoolSize:           slaveOptions.RPCPoolSize,
+		UseSSL:                subordinateOptions.UseSSL,
+		SSLInsecureSkipVerify: subordinateOptions.SSLInsecureSkipVerify,
+		ConnectionString:      subordinateOptions.ConnectionString,
+		RPCKey:                subordinateOptions.RPCKey,
+		APIKey:                subordinateOptions.APIKey,
+		GroupID:               subordinateOptions.GroupID,
+		CallTimeout:           subordinateOptions.CallTimeout,
+		PingTimeout:           subordinateOptions.PingTimeout,
+		RPCPoolSize:           subordinateOptions.RPCPoolSize,
 	}
 
 	return rpc.Connect(
@@ -195,7 +195,7 @@ func (r *RPCStorageHandler) GetKey(keyName string) (string, error) {
 
 func (r *RPCStorageHandler) GetRawKey(keyName string) (string, error) {
 	// Check the cache first
-	if config.Global().SlaveOptions.EnableRPCCache {
+	if config.Global().SubordinateOptions.EnableRPCCache {
 		log.Debug("Using cache for: ", keyName)
 		cachedVal, found := RPCGlobalCache.Get(keyName)
 		log.Debug("--> Found? ", found)
@@ -222,7 +222,7 @@ func (r *RPCStorageHandler) GetRawKey(keyName string) (string, error) {
 		log.Debug("Error trying to get value:", err)
 		return "", storage.ErrKeyNotFound
 	}
-	if config.Global().SlaveOptions.EnableRPCCache {
+	if config.Global().SubordinateOptions.EnableRPCCache {
 		// Cache key
 		RPCGlobalCache.Set(keyName, value, cache.DefaultExpiration)
 	}
@@ -718,7 +718,7 @@ func (r *RPCStorageHandler) CheckForReload(orgId string) {
 }
 
 func (r *RPCStorageHandler) StartRPCLoopCheck(orgId string) {
-	if config.Global().SlaveOptions.DisableKeySpaceSync {
+	if config.Global().SubordinateOptions.DisableKeySpaceSync {
 		return
 	}
 
@@ -766,7 +766,7 @@ func (r *RPCStorageHandler) CheckForKeyspaceChanges(orgId string) {
 	var req interface{}
 
 	reqData := map[string]string{}
-	if groupID := config.Global().SlaveOptions.GroupID; groupID == "" {
+	if groupID := config.Global().SubordinateOptions.GroupID; groupID == "" {
 		funcName = "GetKeySpaceUpdate"
 		req = orgId
 		reqData["orgId"] = orgId
@@ -812,7 +812,7 @@ func getSessionAndCreate(keyName string, r *RPCStorageHandler) {
 	newKeyName := "apikey-" + storage.HashStr(keyName)
 	sessionString, err := r.GetRawKey(keyName)
 	if err != nil {
-		log.Error("Key not found in master - skipping")
+		log.Error("Key not found in main - skipping")
 	} else {
 		handleAddKey(keyName, newKeyName[7:], sessionString, "-1")
 	}

--- a/tyk/gateway/server.go
+++ b/tyk/gateway/server.go
@@ -258,11 +258,11 @@ func syncAPISpecs() (int, error) {
 		apiSpecs = tmpSpecs
 
 		mainLog.Debug("Downloading API Configurations from Dashboard Service")
-	} else if config.Global().SlaveOptions.UseRPC {
+	} else if config.Global().SubordinateOptions.UseRPC {
 		mainLog.Debug("Using RPC Configuration")
 
 		var err error
-		apiSpecs, err = loader.FromRPC(config.Global().SlaveOptions.RPCKey)
+		apiSpecs, err = loader.FromRPC(config.Global().SubordinateOptions.RPCKey)
 		if err != nil {
 			return 0, err
 		}
@@ -305,7 +305,7 @@ func syncPolicies() (count int, err error) {
 		pols = LoadPoliciesFromDashboard(connStr, config.Global().NodeSecret, config.Global().Policies.AllowExplicitPolicyID)
 	case "rpc":
 		mainLog.Debug("Using Policies from RPC")
-		pols, err = LoadPoliciesFromRPC(config.Global().SlaveOptions.RPCKey)
+		pols, err = LoadPoliciesFromRPC(config.Global().SubordinateOptions.RPCKey)
 	default:
 		// this is the only case now where we need a policy record name
 		if config.Global().Policies.PolicyRecordName == "" {
@@ -399,7 +399,7 @@ func loadAPIEndpoints(muxer *mux.Router) {
 		r.HandleFunc("/oauth/refresh/{keyName}", invalidateOauthRefresh).Methods("DELETE")
 		r.HandleFunc("/cache/{apiID}", invalidateCacheHandler).Methods("DELETE")
 	} else {
-		mainLog.Info("Node is slaved, REST API minimised")
+		mainLog.Info("Node is subordinated, REST API minimised")
 	}
 
 	r.HandleFunc("/debug", traceHandler).Methods("POST")
@@ -908,16 +908,16 @@ func initialiseSystem() error {
 // afterConfSetup takes care of non-sensical config values (such as zero
 // timeouts) and sets up a few globals that depend on the config.
 func afterConfSetup(conf *config.Config) {
-	if conf.SlaveOptions.CallTimeout == 0 {
-		conf.SlaveOptions.CallTimeout = 30
+	if conf.SubordinateOptions.CallTimeout == 0 {
+		conf.SubordinateOptions.CallTimeout = 30
 	}
 
-	if conf.SlaveOptions.PingTimeout == 0 {
-		conf.SlaveOptions.PingTimeout = 60
+	if conf.SubordinateOptions.PingTimeout == 0 {
+		conf.SubordinateOptions.PingTimeout = 60
 	}
 
-	rpc.GlobalRPCPingTimeout = time.Second * time.Duration(conf.SlaveOptions.PingTimeout)
-	rpc.GlobalRPCCallTimeout = time.Second * time.Duration(conf.SlaveOptions.CallTimeout)
+	rpc.GlobalRPCPingTimeout = time.Second * time.Duration(conf.SubordinateOptions.PingTimeout)
+	rpc.GlobalRPCCallTimeout = time.Second * time.Duration(conf.SubordinateOptions.CallTimeout)
 	initGenericEventHandlers(conf)
 	regexp.ResetCache(time.Second*time.Duration(conf.RegexpCacheExpire), !conf.DisableRegexpCache)
 
@@ -942,7 +942,7 @@ func getHostDetails() {
 }
 
 func getGlobalStorageHandler(keyPrefix string, hashKeys bool) storage.Handler {
-	if config.Global().SlaveOptions.UseRPC {
+	if config.Global().SubordinateOptions.UseRPC {
 		return &RPCStorageHandler{
 			KeyPrefix: keyPrefix,
 			HashKeys:  hashKeys,
@@ -1137,7 +1137,7 @@ func start() {
 		go startPubSubLoop()
 	}
 
-	if slaveOptions := config.Global().SlaveOptions; slaveOptions.UseRPC {
+	if subordinateOptions := config.Global().SubordinateOptions; subordinateOptions.UseRPC {
 		mainLog.Debug("Starting RPC reload listener")
 		RPCListener = RPCStorageHandler{
 			KeyPrefix:        "rpc.listener.",
@@ -1145,9 +1145,9 @@ func start() {
 		}
 
 		RPCListener.Connect()
-		go rpcReloadLoop(slaveOptions.RPCKey)
+		go rpcReloadLoop(subordinateOptions.RPCKey)
 		go RPCListener.StartRPCKeepaliveWatcher()
-		go RPCListener.StartRPCLoopCheck(slaveOptions.RPCKey)
+		go RPCListener.StartRPCLoopCheck(subordinateOptions.RPCKey)
 	}
 
 	// 1s is the minimum amount of time between hot reloads. The

--- a/tyk/gateway/service_discovery_test.go
+++ b/tyk/gateway/service_discovery_test.go
@@ -152,7 +152,7 @@ const mesosphere = `{
 		"startedAt": "2016-03-15T14:37:55.941Z",
 		"stagedAt": "2016-03-15T14:37:52.792Z",
 		"version": "2016-03-15T14:37:52.726Z",
-		"slaveId": "d70867df-fdb2-4889-abeb-0829c742fded-S2",
+		"subordinateId": "d70867df-fdb2-4889-abeb-0829c742fded-S2",
 		"appId": "/httpbin"
 	}]
 }`

--- a/tyk/vendor/github.com/TykTechnologies/redigocluster/rediscluster/rediscluster.go
+++ b/tyk/vendor/github.com/TykTechnologies/redigocluster/rediscluster/rediscluster.go
@@ -197,7 +197,7 @@ func (self *RedisCluster) KeyForRequest(cmd string, args ...interface{}) string 
 	if cmd == "info" ||
 		cmd == "multi" ||
 		cmd == "exec" ||
-		cmd == "slaveof" ||
+		cmd == "subordinateof" ||
 		cmd == "config" ||
 		cmd == "shutdown" {
 		return ""

--- a/tyk/vendor/github.com/golang/protobuf/proto/discard.go
+++ b/tyk/vendor/github.com/golang/protobuf/proto/discard.go
@@ -60,7 +60,7 @@ func DiscardUnknown(m Message) {
 		return
 	}
 	// TODO: Dynamically populate a InternalMessageInfo for legacy messages,
-	// but the master branch has no implementation for InternalMessageInfo,
+	// but the main branch has no implementation for InternalMessageInfo,
 	// so it would be more work to replicate that approach.
 	discardLegacy(m)
 }

--- a/tyk/vendor/github.com/mattn/go-isatty/isatty_windows.go
+++ b/tyk/vendor/github.com/mattn/go-isatty/isatty_windows.go
@@ -38,7 +38,7 @@ func IsTerminal(fd uintptr) bool {
 
 // Check pipe name is used for cygwin/msys2 pty.
 // Cygwin/MSYS2 PTY has a name like:
-//   \{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master
+//   \{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-main
 func isCygwinPipeName(name string) bool {
 	token := strings.Split(name, "-")
 	if len(token) < 5 {
@@ -61,7 +61,7 @@ func isCygwinPipeName(name string) bool {
 		return false
 	}
 
-	if token[4] != "master" {
+	if token[4] != "main" {
 		return false
 	}
 

--- a/tyk/vendor/github.com/miekg/dns/xfr.go
+++ b/tyk/vendor/github.com/miekg/dns/xfr.go
@@ -29,10 +29,10 @@ type Transfer struct {
 // in the Transfer.Conn:
 //
 //	d := net.Dialer{LocalAddr: transfer_source}
-//	con, err := d.Dial("tcp", master)
+//	con, err := d.Dial("tcp", main)
 //	dnscon := &dns.Conn{Conn:con}
 //	transfer = &dns.Transfer{Conn: dnscon}
-//	channel, err := transfer.In(message, master)
+//	channel, err := transfer.In(message, main)
 //
 func (t *Transfer) In(q *Msg, a string) (env chan *Envelope, err error) {
 	timeout := dnsTimeout

--- a/tyk/vendor/gopkg.in/Masterminds/sprig.v2/crypto.go
+++ b/tyk/vendor/gopkg.in/Masterminds/sprig.v2/crypto.go
@@ -48,7 +48,7 @@ func uuidv4() string {
 	return fmt.Sprintf("%s", uuid.New())
 }
 
-var master_password_seed = "com.lyndir.masterpassword"
+var main_password_seed = "com.lyndir.mainpassword"
 
 var password_type_templates = map[string][][]byte{
 	"maximum": {[]byte("anoxxxxxxxxxxxxxxxxx"), []byte("axxxxxxxxxxxxxxxxxno")},
@@ -82,7 +82,7 @@ func derivePassword(counter uint32, password_type, password, user, site string) 
 	}
 
 	var buffer bytes.Buffer
-	buffer.WriteString(master_password_seed)
+	buffer.WriteString(main_password_seed)
 	binary.Write(&buffer, binary.BigEndian, uint32(len(user)))
 	buffer.WriteString(user)
 
@@ -92,7 +92,7 @@ func derivePassword(counter uint32, password_type, password, user, site string) 
 		return fmt.Sprintf("failed to derive password: %s", err)
 	}
 
-	buffer.Truncate(len(master_password_seed))
+	buffer.Truncate(len(main_password_seed))
 	binary.Write(&buffer, binary.BigEndian, uint32(len(site)))
 	buffer.WriteString(site)
 	binary.Write(&buffer, binary.BigEndian, counter)

--- a/tyk/vendor/gopkg.in/Masterminds/sprig.v2/doc.go
+++ b/tyk/vendor/gopkg.in/Masterminds/sprig.v2/doc.go
@@ -14,6 +14,6 @@ Note that you should add the function map before you parse any template files.
 	appear in the standard library. This is to make it easier to pipe
 	arguments into functions.
 
-See http://masterminds.github.io/sprig/ for more detailed documentation on each of the available functions.
+See http://mainminds.github.io/sprig/ for more detailed documentation on each of the available functions.
 */
 package sprig


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.